### PR TITLE
Show vaccine deaths

### DIFF
--- a/jeockovanibezpecne/static/css/main.css
+++ b/jeockovanibezpecne/static/css/main.css
@@ -92,7 +92,7 @@ p.answer {
   white-space: nowrap;
 }
 
-.comparison .side-effects {
+.comparison .vaccine-deaths {
   color: #00B0C7;
 }
 

--- a/jeockovanibezpecne/templates/index.jinja2
+++ b/jeockovanibezpecne/templates/index.jinja2
@@ -39,8 +39,8 @@
         </h2>
         <p class="count vaccinated">{{ vaccinated | fmt_number }}</p>
         <h3>očkovaných</h3>
-        <p class="count side-effects">{{ submit.submits | fmt_number }}</p>
-        <h3 class="side-effects">s&nbsp;vedlejšími<br/>účinky</h3>
+        <p class="count vaccine-deaths">0</p>
+        <h3 class="vaccine-deaths">zemřelých</h3>
       </section>
       <section class="virus">
         <h2>


### PR DESCRIPTION
After receiving a lot of feedback, we've decided to show number of deaths caused by vaccines (0) instead.